### PR TITLE
[Feat] : kakaoUserInfo to DB

### DIFF
--- a/src/main/java/com/umc/commonplant/domain/user/controller/UserController.java
+++ b/src/main/java/com/umc/commonplant/domain/user/controller/UserController.java
@@ -29,8 +29,7 @@ public class UserController {
     }
     @GetMapping("/login/{provider}")
     public ResponseEntity<JsonResponse> login(@RequestParam("accessToken") String accessToken, @PathVariable String provider){
-        log.info("accessToken" + accessToken);
-//        System.out.println("accessToken: " + accessToken);
+        log.info("accessToken :" + accessToken);
         String token = oAuthService.oAuthLogin(accessToken, provider);
 
         return ResponseEntity.ok(new JsonResponse(true, 200, "login", token));

--- a/src/main/java/com/umc/commonplant/domain/user/dto/KakaoProfile.java
+++ b/src/main/java/com/umc/commonplant/domain/user/dto/KakaoProfile.java
@@ -11,7 +11,7 @@ public class KakaoProfile {
 
     @Data
     public static class Properties{
-        private String name;
+        private String nickname;
         private String profile_image;
         private String thumbnail_image;
     }
@@ -29,7 +29,7 @@ public class KakaoProfile {
 
     @Data
     public static class Profile{
-        private String name;
+        private String nickname;
         private String profile_image_url;
         private boolean is_default_image;
     }

--- a/src/main/java/com/umc/commonplant/domain/user/service/UserService.java
+++ b/src/main/java/com/umc/commonplant/domain/user/service/UserService.java
@@ -39,7 +39,7 @@ public class UserService {
         }else{
             //join
             String uuid = UuidUtil.generateType1UUID();
-            //String imageUrl = firebaseService.uploadFiles(uuid, image);
+//            String imageUrl = firebaseService.uploadFiles(uuid, image);
 
             User user = User.builder()
                     .name(req.getName())


### PR DESCRIPTION
## 🚀 관련 이슈
- 카카오 유저정보 DB저장

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 카카오로그인(액세스 토큰) 회원정보 가져옴 
-    → DB에 있음 → 로그인 성공
      → DB에 없음 → 회원가입 후(DB저장) 로그인

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [x] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
-  DB에 등록되어있지 않은 경우 회원가입을 진행

## 📔 참고 자료
- 선택 사항
