### PR TITLE
[Fix] Add information 중복된 학술명 검사 로직 추가

### DIFF
--- a/src/main/java/com/umc/commonplant/domain2/info/entity/InfoRepository.java
+++ b/src/main/java/com/umc/commonplant/domain2/info/entity/InfoRepository.java
@@ -13,6 +13,8 @@ public interface InfoRepository extends JpaRepository<Info, Long> {
 
     List<Info> findByName(String name);
 
+    boolean existsByScientificName(String scientificName);
+
     @Query("SELECT i FROM Info i WHERE (i.name = :keyword OR i.scientificName = :keyword) AND i.verified = true")
     Optional<Info> findVerifiedByNameOrScientificName(@Param("keyword") String keyword);
 

--- a/src/main/java/com/umc/commonplant/domain2/info/service/InfoService.java
+++ b/src/main/java/com/umc/commonplant/domain2/info/service/InfoService.java
@@ -42,10 +42,18 @@ public class InfoService {
             }
             throw new GlobalException(ErrorResponseStatus.ALREADY_EXIST_INFO);
         }
-        try {
-            if(info.getVerified() == null) {
-                info.setVerified(false);
+        if(info.getVerified() == null) {
+            info.setVerified(false);
+        }
+
+        String scientific_name = info.getScientificName();
+        if(!scientific_name.isEmpty() && !scientific_name.isBlank()) {
+            if(infoRepository.existsByScientificName(scientific_name)) {
+                throw new GlobalException(ErrorResponseStatus.ALREADY_EXIST_INFO);
             }
+        }
+
+        try {
             infoRepository.save(info);
         } catch (Exception e) {
             throw new GlobalException(ErrorResponseStatus.DATABASE_ERROR);


### PR DESCRIPTION
## 🚀 관련 이슈
- #25 

## 🔑 주요 변경사항
- Information의 식물 정보 추가할 시 학술명이 존재할 경우, 이미 등록되어 있는 학술명은 등록 불가하도록 로직 추가

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
- 

## 📔 참고 자료
- 선택 사항
