### PR TITLE
[Feat] deletePlace

### DIFF
--- a/src/main/java/com/umc/commonplant/domain/belong/entity/BelongRepository.java
+++ b/src/main/java/com/umc/commonplant/domain/belong/entity/BelongRepository.java
@@ -12,6 +12,9 @@ public interface BelongRepository extends JpaRepository<Belong, Long> {
     @Query("select b.user from Belong b where b.place.code=?1")
     Optional<List<User>> getUserListByPlaceCode(String code);
 
+    @Query("select b.user from Belong b where b.place.code=?1 order by b.createdAt")
+    Optional<List<User>> getUserListByPlaceCodeOrderByCreatedAt(String code);
+
     @Query("select b.place from Belong b where b.user.uuid=?1")
     List<Place> getPlaceListByUser(String uuid);
 
@@ -25,4 +28,7 @@ public interface BelongRepository extends JpaRepository<Belong, Long> {
 
     @Query("select b from Belong b where b.user.uuid = ?1 and b.place.code = ?2")
     Optional<Belong> getBelongByUserAndPlace(String uuid, String code);
+
+    @Query("select count(b.belongIdx) from Belong b where b.place.code = ?1")
+    Integer getNumberOfUserInPlace(String code);
 }

--- a/src/main/java/com/umc/commonplant/domain/belong/entity/BelongRepository.java
+++ b/src/main/java/com/umc/commonplant/domain/belong/entity/BelongRepository.java
@@ -22,4 +22,7 @@ public interface BelongRepository extends JpaRepository<Belong, Long> {
 
     @Query("select b from Belong b where b.user.uuid=?1")
     List<Belong> getPlaceBelongUser(String uuid);
+
+    @Query("select b from Belong b where b.user.uuid = ?1 and b.place.code = ?2")
+    Optional<Belong> getBelongByUserAndPlace(String uuid, String code);
 }

--- a/src/main/java/com/umc/commonplant/domain/place/controller/PlaceContoller.java
+++ b/src/main/java/com/umc/commonplant/domain/place/controller/PlaceContoller.java
@@ -161,11 +161,15 @@ public class PlaceContoller implements PlaceSwagger{
     //        - 팀원이 등록된 순서대로 팀짱 넘겨주기!!
     //        - 장소 수정에서 팀장을 넘겨줄 수 있게!! (일단 디자인 반영!!)
     //        → 모든 사용자가 장소 탈퇴시 장소는 삭제
-//    @DeleteMapping("/delete/{code}")
-//    public ResponseEntity<JsonResponse> deletePlace(@PathVariable String code){
-//
-//    }
+    @DeleteMapping("/delete/{code}")
+    public ResponseEntity<JsonResponse> deletePlace(@PathVariable String code){
+        log.info("[API] leavePlace");
+        String uuid = jwtService.resolveToken();
+        User user = userService.getUser(uuid);
 
+        placeService.leavePlace(user, code);
 
+        return ResponseEntity.ok(new JsonResponse(true, 200, "leavePlace", null));
+    }
 
 }

--- a/src/main/java/com/umc/commonplant/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/umc/commonplant/domain/place/controller/PlaceController.java
@@ -163,7 +163,7 @@ public class PlaceController implements PlaceSwagger{
     //        → 모든 사용자가 장소 탈퇴시 장소는 삭제
     @DeleteMapping("/delete/{code}")
     public ResponseEntity<JsonResponse> deletePlace(@PathVariable String code){
-        log.info("[API] leavePlace");
+        log.info("[API] deletePlace");
         String uuid = jwtService.resolveToken();
         User user = userService.getUser(uuid);
 

--- a/src/main/java/com/umc/commonplant/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/umc/commonplant/domain/place/controller/PlaceController.java
@@ -23,7 +23,7 @@ import java.util.List;
 @RequestMapping("/place")
 @RequiredArgsConstructor
 @RestController
-public class PlaceContoller implements PlaceSwagger{
+public class PlaceController implements PlaceSwagger{
     private final PlaceService placeService;
     private final UserService userService;
     private final JwtService jwtService;

--- a/src/main/java/com/umc/commonplant/domain/place/entity/Place.java
+++ b/src/main/java/com/umc/commonplant/domain/place/entity/Place.java
@@ -58,4 +58,8 @@ public class Place extends BaseTime {
     public void setPlaceIdx(Long placeIdx) {
         this.placeIdx = placeIdx;
     }
+
+    public void setOwner(User owner) {
+        this.owner = owner;
+    }
 }

--- a/src/main/java/com/umc/commonplant/domain/place/service/PlaceService.java
+++ b/src/main/java/com/umc/commonplant/domain/place/service/PlaceService.java
@@ -3,13 +3,17 @@ package com.umc.commonplant.domain.place.service;
 import com.umc.commonplant.domain.belong.entity.Belong;
 import com.umc.commonplant.domain.belong.entity.BelongRepository;
 import com.umc.commonplant.domain.image.service.ImageService;
+import com.umc.commonplant.domain.memo.entity.Memo;
+import com.umc.commonplant.domain.memo.entity.MemoRepository;
 import com.umc.commonplant.domain.place.dto.PlaceDto;
 import com.umc.commonplant.domain.place.entity.Place;
 import com.umc.commonplant.domain.place.entity.PlaceRepository;
+import com.umc.commonplant.domain.plant.entity.Plant;
 import com.umc.commonplant.domain.plant.entity.PlantRepository;
 import com.umc.commonplant.domain.user.entity.User;
 import com.umc.commonplant.domain.user.repository.UserRepository;
 import com.umc.commonplant.global.exception.BadRequestException;
+import com.umc.commonplant.global.utils.UuidUtil;
 import com.umc.commonplant.global.utils.openAPI.OpenApiService;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -35,6 +39,7 @@ public class PlaceService {
     private final OpenApiService openApiService;
     private final ImageService imageService;
     private final PlantRepository plantRepository;
+    private final MemoRepository memoRepository;
 
 
     @Transactional
@@ -191,7 +196,39 @@ public class PlaceService {
         );
     }
 
+    @Transactional
+    public void leavePlace(User user, String code) {
+        Place place = getPlaceByCode(code);
 
+        Optional<Belong> belongInfo = belongRepository.getBelongByUserAndPlace(user.getUuid(), place.getCode());
+        if(belongInfo.isEmpty()) throw new BadRequestException(NOT_FOUND_USER_ON_PLACE);
+        Belong belong = belongInfo.get();
+
+        List<Long> plants = plantRepository.findAllByPlace(place).stream()
+                .map(Plant::getPlantIdx)
+                .collect(Collectors.toList());
+
+        User unknownUser = createUnknownUser();
+
+        for(Long plantIdx : plants) {
+            List<Memo> memos = memoRepository.findByPlantIdx(plantIdx);
+
+            for(Memo memo : memos) {
+                if(memo.getUser().equals(user)) {
+                    Memo unknownMemo = Memo.builder()
+                            .memoIdx(memo.getMemoIdx())
+                            .user(unknownUser)
+                            .plant(memo.getPlant())
+                            .imgUrl(memo.getImgUrl())
+                            .content(memo.getContent())
+                            .build();
+                    memoRepository.save(unknownMemo);
+                }
+            }
+        }
+
+        belongRepository.delete(belong);
+    }
 
     // ----- API 외 메서드 -----
 
@@ -212,5 +249,20 @@ public class PlaceService {
         return belongRepository.getPlaceListByUser(user.getUuid());
     }
 
+    // 장소에서 탈퇴한 팀원을 '알 수 없음'으로 변환
+    public User createUnknownUser() {
+        Optional<User> user = userRepository.findByname("알 수 없음");
+
+        if(!userRepository.existsByname("알 수 없음")) {
+            String uuid = UuidUtil.generateType1UUID();
+            User unknownUser = new User("알 수 없음", "unknown@unknown.com", null, null, null, uuid);
+
+            userRepository.save(unknownUser);
+
+            return unknownUser;
+        } else {
+            return user.get();
+        }
+    }
 
 }

--- a/src/main/java/com/umc/commonplant/domain/place/service/PlaceService.java
+++ b/src/main/java/com/umc/commonplant/domain/place/service/PlaceService.java
@@ -228,6 +228,13 @@ public class PlaceService {
         }
 
         belongRepository.delete(belong);
+
+        if(belongRepository.getNumberOfUserInPlace(code) == 0) {
+            // TODO: 장소 완전 삭제
+        } else {
+            changeOwnerOfPlace(user, place.getCode());
+        }
+
     }
 
     // ----- API 외 메서드 -----
@@ -262,6 +269,19 @@ public class PlaceService {
             return unknownUser;
         } else {
             return user.get();
+        }
+    }
+
+    // 팀짱 넘겨주기
+    public void changeOwnerOfPlace(User user, String code) {
+        Place place = getPlaceByCode(code);
+
+        if(place.getOwner().equals(user)) {
+            List<User> users = belongRepository.getUserListByPlaceCodeOrderByCreatedAt(place.getCode())
+                    .orElseThrow(() -> new BadRequestException(NOT_FOUND_PLACE_CODE));;
+            place.setOwner(users.get(0));
+
+            placeRepository.save(place);
         }
     }
 


### PR DESCRIPTION
## 🚀 관련 이슈
- #18 

## 🔑 주요 변경사항
- 장소 탈퇴 구현 (`leavePlace()`)
1. 팀짱이 탈퇴할 경우 `changeOwnerOfPlace()` 추가 실행
2. 탈퇴한 팀원이 남긴 메모는 남아있는 팀원들에게 **알 수 없음**으로 처리
3. **알 수 없음**이라는 사용자를 만드는 함수 생성 (`createUnknownUser()`)

- 장소 완전 삭제 구현 (`deletePlace()`)
1. `leavePlace()` 실행 결과 장소에 남아있는 팀원이 아무도 없게 된다면 장소 완전 삭제
2. 장소 -> 식물 -> 메모 순으로 조회 후, 메모 -> 식물 -> 장소 순으로 삭제
